### PR TITLE
fix: drop unsupported python version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,6 @@ classifiers = [
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Cython',
     'Topic :: Scientific/Engineering :: Information Analysis',
     'Topic :: Scientific/Engineering :: Mathematics'


### PR DESCRIPTION
Running setup.py on later versions of python will raise a RuntimeError on line 15.