### PR TITLE
Revert "fix: drop unsupported python version classifiers"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ classifiers = [
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Programming Language :: Cython',
     'Topic :: Scientific/Engineering :: Information Analysis',
     'Topic :: Scientific/Engineering :: Mathematics'


### PR DESCRIPTION
Reverts djordon/queueing-tool#49

I can't read.